### PR TITLE
[FE] style: style 설정 (공통 색상, font-family)

### DIFF
--- a/front/src/GlobalStyle.js
+++ b/front/src/GlobalStyle.js
@@ -2,6 +2,9 @@ import { createGlobalStyle } from 'styled-components';
 import reset from 'styled-reset';
 
 const GlobalStyle = createGlobalStyle`
-  ${reset}
+  ${reset}, 
+  body {
+    font-family: RobotoInCjk, "Noto Sans KR", "Apple SD Gothic Neo", "Nanum Gothic", "Malgun Gothic", sans-serif;
+  }
 `;
 export default GlobalStyle;

--- a/front/src/styles/theme.js
+++ b/front/src/styles/theme.js
@@ -1,0 +1,16 @@
+const colors = {
+  mainColor: '#6741FF',
+  purple_1: '#A28BFF',
+  purple_2: '#CFC3FF',
+  purple_3: '#E8E2FF',
+  dark: '#232627',
+  darygray: '#A28BFF',
+  gray: '#737373',
+  lightgray: '#BFBFBF',
+};
+
+const theme = {
+  colors,
+};
+
+export default theme;


### PR DESCRIPTION
![Group 22 (3)](https://user-images.githubusercontent.com/70098708/201364194-41110e3d-122e-49c8-aa6a-31b17f220a5b.png)


style/theme.js 파일 추가해서 공통으로 사용할 색상들 설정해 놓았습니다!
만약에 공통으로 사용할 css 속성이 있으면 더 추가해서 사용하셔도 됩니다. 

사용법은 노션에 정리해놓았습니다!
https://www.notion.so/codestates/f32db5076a304ab4bdb6d977e2891d51