### PR TITLE
[BE] fix: Refresh Token 수정

### DIFF
--- a/back/src/main/java/seb40_main_012/back/config/CorsConfig.java
+++ b/back/src/main/java/seb40_main_012/back/config/CorsConfig.java
@@ -13,7 +13,7 @@ public class CorsConfig implements WebMvcConfigurer {
                 .allowedOrigins("http://localhost:3000",
                         "http://main-012-client.s3-website.ap-northeast-2.amazonaws.com")
                 .allowedMethods("*")
-                .exposedHeaders("Authorization", "Refresh")
+                .exposedHeaders("Authorization", "Set-Cookie")
                 .allowCredentials(true)
                 .maxAge(3000);
     }

--- a/back/src/main/java/seb40_main_012/back/config/auth/SecurityController.java
+++ b/back/src/main/java/seb40_main_012/back/config/auth/SecurityController.java
@@ -1,0 +1,66 @@
+package seb40_main_012.back.config.auth;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import seb40_main_012.back.config.auth.jwt.JwtTokenizer;
+import seb40_main_012.back.config.auth.utils.CustomAuthorityUtils;
+import seb40_main_012.back.user.entity.User;
+import seb40_main_012.back.user.service.UserService;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api")
+public class SecurityController {
+    private final JwtTokenizer jwtTokenizer;
+    private final CustomAuthorityUtils authorityUtils;
+    private final UserService userService;
+
+    @GetMapping("/token/refresh")
+    public void refreshToken(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        try {
+            String refreshToken = outCookie(request);
+
+            String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());
+            String email = (String) jwtTokenizer.getClaims(refreshToken, base64EncodedSecretKey).getBody().get("sub");
+
+            User findUser = userService.findUserByEmail(email);
+            String accessToken = delegateAccessToken(findUser, base64EncodedSecretKey);
+
+            response.setHeader("Authorization", "Bearer " + accessToken);
+            response.setHeader("Set-Cookie", request.getHeader("Set-Cookie"));
+        } catch (ExpiredJwtException ee) {
+            response.sendError(401, "Refresh Token이 만료되었습니다");
+        }
+
+    }
+
+    private String delegateAccessToken(User user, String base64EncodedSecretKey) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("email", user.getEmail());
+        claims.put("roles", user.getRoles());
+
+        Date expiration = jwtTokenizer.getTokenExpiration(jwtTokenizer.getAccessTokenExpirationMinutes());
+        String accessToken = jwtTokenizer.generateAccessToken(claims, user.getEmail(), expiration, base64EncodedSecretKey);
+
+        return accessToken;
+    }
+
+    private String outCookie(HttpServletRequest request) {
+        String[] cookies = request.getHeader("Set-Cookie").split(";");
+        String refreshToken = Arrays.stream(cookies)
+                .filter(cookie -> cookie.startsWith("refreshToken"))
+                .findFirst()
+                .map(cookieString -> cookieString.replace("refreshToken=", ""))
+                .orElse(null);
+
+        return refreshToken;
+    }
+}

--- a/back/src/main/java/seb40_main_012/back/config/auth/filter/JwtAuthenticationFilter.java
+++ b/back/src/main/java/seb40_main_012/back/config/auth/filter/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package seb40_main_012.back.config.auth.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -52,10 +53,19 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         responseDto.setNickName(user.getNickName());
         responseDto.setEmail(user.getEmail());
         responseDto.setRoles(user.getRoles());
-
         response.getWriter().write(mapper.writeValueAsString(responseDto));
+
         response.setHeader("Authorization", "Bearer " + accessToken);
-        response.setHeader("Refresh", refreshToken);
+
+        // refresh Token을 헤더에 Set-Cookie 해주기
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+                .maxAge(7 * 24 * 60 * 60)
+                .path("/")
+                .secure(true)
+                .sameSite("None")
+                .httpOnly(true)
+                .build();
+        response.setHeader("Set-Cookie", cookie.toString());
 
         this.getSuccessHandler().onAuthenticationSuccess(request, response, authResult); // 핸들러 호출
     }

--- a/back/src/main/java/seb40_main_012/back/config/auth/filter/JwtVerificationFilter.java
+++ b/back/src/main/java/seb40_main_012/back/config/auth/filter/JwtVerificationFilter.java
@@ -9,14 +9,15 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 import seb40_main_012.back.config.auth.jwt.JwtTokenizer;
 import seb40_main_012.back.config.auth.utils.CustomAuthorityUtils;
+import seb40_main_012.back.user.entity.User;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class JwtVerificationFilter extends OncePerRequestFilter {
     private final JwtTokenizer jwtTokenizer;
@@ -35,8 +36,9 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
             setAuthenticationToContext(claims);
         } catch (SignatureException se) {
             request.setAttribute("exception", se);
-        } catch (ExpiredJwtException ee) {
+        } catch (ExpiredJwtException ee) { // AccessToken 기간 만료
             request.setAttribute("exception", ee);
+            response.sendError(401, "Access Token이 만료되었습니다");
         } catch (Exception e) {
             request.setAttribute("exception", e);
         }

--- a/back/src/main/java/seb40_main_012/back/user/service/UserService.java
+++ b/back/src/main/java/seb40_main_012/back/user/service/UserService.java
@@ -113,4 +113,10 @@ public class UserService {
         return user;
     }
 
+    public User findUserByEmail(String email) { // 이메일로 유저 찾기
+        Optional<User> optionalUser = userRepository.findByEmail(email);
+        User findUser = optionalUser.orElseThrow(() -> new BusinessLogicException(ExceptionCode.USER_NOT_FOUND));
+
+        return findUser;
+    }
 }

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -32,5 +32,5 @@ mail:
     admin: admin@gmail.com
 jwt:
   secret-key: temporary1111potato1111temporary1111potato # ${JWT_SECRET_KEY}
-  access-token-expiration-minutes: 1
-  refresh-token-expiration-minutes: 3
+  access-token-expiration-minutes: 30
+  refresh-token-expiration-minutes: 420

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -18,10 +18,19 @@ server:
       location: ""
       maxFileSize: 5MB
       maxRequestSize: 10MB
+  error:
+    include-stacktrace: never
+#  port: 443
+#  ssl:
+#    enabled: true
+#    key-store: back/src/main/resources/bootsecurity.p12
+#    key-store-password: mhyMHY#1040
+#    key-store-type: PKCS12
+#    key-alias: bootsecurity
 mail:
   address:
     admin: admin@gmail.com
 jwt:
   secret-key: temporary1111potato1111temporary1111potato # ${JWT_SECRET_KEY}
-  access-token-expiration-minutes: 30
-  refresh-token-expiration-minutes: 420
+  access-token-expiration-minutes: 1
+  refresh-token-expiration-minutes: 3


### PR DESCRIPTION
- 수정 사항
  - refresh token을 cookie에 담기
  ![image](https://user-images.githubusercontent.com/39071652/202062694-596a9852-3cef-4e58-b657-394646115296.png)

- 추가 사항
  - refresh token으로 access token 재발급하기
    ![image](https://user-images.githubusercontent.com/39071652/202063394-912070fe-077b-40d4-96a1-a6aff14a5dd8.png)
    - request 헤더에 Set-Cookie를 넣어 요청해 주세요
    - 응답 헤더에 access token이 재발급 되어서 옵니다 (refresh token은 그대로 입니다!)
  - 오류 메시지
    - access token이 만료되었을 때
      ![image](https://user-images.githubusercontent.com/39071652/202063741-17ca5ed3-f34b-44d2-b199-abcf45f2aa79.png)
    - refresh token이 만료되었을 때
      ![image](https://user-images.githubusercontent.com/39071652/202063648-8e8912a5-2cdb-4935-876d-039acdbfcf7d.png)

    