### PR TITLE
[FE] pairing 목록 및 상세 1차 구현

### DIFF
--- a/front/src/App.js
+++ b/front/src/App.js
@@ -13,6 +13,14 @@ import EditProfile from './pages/MyPage/EditProfile/EditProfile';
 import CollectionDetailPage from './pages/CollectionDetailPage/CollectionDetail';
 import ChangePassWd from './pages/MyPage/EditProfile/ChangePassWd';
 
+import PairingPage from './pages/PairingPage/PairingAll';
+import PairingFilm from './pages/PairingPage/PairingFilm';
+import PairingCuisine from './pages/PairingPage/PairingCuisine';
+import PairingMusic from './pages/PairingPage/PairingMusic';
+import PairingBook from './pages/PairingPage/PairingBook';
+import PairingEtc from './pages/PairingPage/PairingEtc';
+import PairingWrite from './pages/PairingPage/PairingWrite/PairingWrite';
+import PairingDetail from './pages/PairingPage/PairingDetail/PairingDetail';
 //임시 페이지!
 import ReduxPage from './pages/Temp_Redux';
 
@@ -23,6 +31,14 @@ const App = () => {
       <Routes>
         <Route path="/redux" element={<ReduxPage />} />
         <Route path="/" element={<MainPage />} />
+        <Route path="/pairing" element={<PairingPage />} />
+        <Route path="/pairing/film" element={<PairingFilm />} />
+        <Route path="/pairing/cuisine" element={<PairingCuisine />} />
+        <Route path="/pairing/music" element={<PairingMusic />} />
+        <Route path="/pairing/book" element={<PairingBook />} />
+        <Route path="/pairing/etc" element={<PairingEtc />} />
+        <Route path="/pairing/write" element={<PairingWrite />} />
+        <Route path="/pairing/:pairingId" element={<PairingDetail />} />
         <Route path="/collection" element={<CollectionPage />} />
         <Route path="/user/signin" element={<SignInPage />} />
         <Route path="/user/signup" element={<SignUpPage />} />
@@ -39,7 +55,6 @@ const App = () => {
           path="/settings/profile/changepasswd"
           element={<ChangePassWd />}
         />
-
         <Route
           path="/collection/:collectionid"
           element={<CollectionDetailPage />}

--- a/front/src/api/requests.js
+++ b/front/src/api/requests.js
@@ -1,2 +1,16 @@
 export const SIGN_UP_URL = '/api/users';
 export const SIGN_IN_URL = '/api/login';
+
+export const PAIRING_URL = '/api/books/pairings';
+export const PAIRING_ALL_LIKE_URL = '/api/books/pairings/likes';
+export const PAIRING_ALL_NEWEST_URL = '/api/books/pairings/newest';
+export const PAIRING_FILM_LIKE_URL = '/api/books/pairings/film/likes';
+export const PAIRING_FILM_NEWEST_URL = '/api/books/pairings/film/newest';
+export const PAIRING_CUISINE_LIKE_URL = '/api/books/pairings/cuisine/likes';
+export const PAIRING_CUISINE_NEWEST_URL = '/api/books/pairings/cuisine/newest';
+export const PAIRING_MUSIC_LIKE_URL = '/api/books/pairings/music/likes';
+export const PAIRING_MUSIC_NEWEST_URL = '/api/books/pairings/music/newest';
+export const PAIRING_BOOK_LIKE_URL = '/api/books/pairings/book/likes';
+export const PAIRING_BOOK_NEWEST_URL = '/api/books/pairings/book/newest';
+export const PAIRING_ETC_LIKE_URL = '/api/books/pairings/etc/likes';
+export const PAIRING_ETC_NEWEST_URL = '/api/books/pairings/etc/newest';

--- a/front/src/pages/PairingPage/PairingAll.js
+++ b/front/src/pages/PairingPage/PairingAll.js
@@ -1,0 +1,31 @@
+import PageContainer from '../../components/PageContainer';
+import PairingTab from './PairingComponents/PairingTab';
+import PairingCuration from './PairingComponents/PairingCuration';
+import { useSelector, useDispatch } from 'react-redux';
+import { useEffect } from 'react';
+import {
+  asyncGetAllPairingLike,
+  asyncGetAllPairingNewest,
+} from '../../store/modules/allPairingSlice';
+const PairingPage = () => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(asyncGetAllPairingLike());
+    dispatch(asyncGetAllPairingNewest());
+  }, [dispatch]);
+
+  const pairingLikeData = useSelector((state) => state.allPairing.likeData);
+  const pairingNewestData = useSelector((state) => state.allPairing.newestData);
+  const titleLike = '큐레이션 제목: Hot Pairing';
+  const titleNewest = '큐레이션 제목: New Pairing';
+  return (
+    <PageContainer footer>
+      <PairingTab />
+      <PairingCuration title={titleLike} pairingData={pairingLikeData} />
+      <PairingCuration title={titleNewest} pairingData={pairingNewestData} />
+      <PairingCuration title={titleLike} pairingData={pairingLikeData} />
+    </PageContainer>
+  );
+};
+
+export default PairingPage;

--- a/front/src/pages/PairingPage/PairingBook.js
+++ b/front/src/pages/PairingPage/PairingBook.js
@@ -1,0 +1,32 @@
+import PageContainer from '../../components/PageContainer';
+import PairingTab from './PairingComponents/PairingTab';
+import PairingCuration from './PairingComponents/PairingCuration';
+import { useSelector, useDispatch } from 'react-redux';
+import { useEffect } from 'react';
+import {
+  asyncGetBookPairingLike,
+  asyncGetBookPairingNewest,
+} from '../../store/modules/bookPairingSlice';
+const PairingBook = () => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(asyncGetBookPairingLike());
+    dispatch(asyncGetBookPairingNewest());
+  }, [dispatch]);
+
+  const pairingLikeData = useSelector((state) => state.bookPairing.likeData);
+  const pairingNewestData = useSelector(
+    (state) => state.bookPairing.newestData
+  );
+  const titleLike = '큐레이션 제목: Hot Pairing';
+  const titleNewest = '큐레이션 제목: New Pairing';
+  return (
+    <PageContainer footer>
+      <PairingTab pathname="/pairing/book" />
+      <PairingCuration title={titleLike} pairingData={pairingLikeData} />
+      <PairingCuration title={titleNewest} pairingData={pairingNewestData} />
+    </PageContainer>
+  );
+};
+
+export default PairingBook;

--- a/front/src/pages/PairingPage/PairingComponents/PairingCuration.js
+++ b/front/src/pages/PairingPage/PairingComponents/PairingCuration.js
@@ -1,0 +1,154 @@
+import styled, { ThemeProvider } from 'styled-components';
+import theme from '../../../styles/theme';
+import { useNavigate } from 'react-router-dom';
+
+const PairingCurationWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  @media screen and (min-width: 981px) {
+    //981px ~
+    flex-direction: row;
+  }
+`;
+const PhotoContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  @media screen and (min-width: 641px) {
+    //641 ~ 980px
+    flex-direction: row;
+  }
+`;
+
+const SecondContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  @media screen and (min-width: 641px) {
+    //641 ~ 980px
+    flex-direction: column;
+  }
+`;
+
+const ColumnContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 5px;
+`;
+
+const FirstPhotoContents = styled.div`
+  width: 100%;
+  height: 300px;
+  margin: 5px;
+  background-color: ${({ theme }) => theme.colors.purple_2};
+  border-radius: 25px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  &:hover {
+    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
+  }
+`;
+
+const OtherPhotoContents = styled.div`
+  width: 100%;
+  height: 140px;
+  margin: 5px;
+  background-color: ${({ theme }) => theme.colors.purple_2};
+  border-radius: 25px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  &:hover {
+    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
+  }
+`;
+
+const LineContents = styled.div`
+  width: 100%;
+  height: 50px;
+  margin: 5px;
+  background-color: ${({ theme }) => theme.colors.purple_3};
+  border-radius: 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  &:hover {
+    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
+  }
+`;
+
+const PairingCuration = ({ title, pairingData }) => {
+  const navigate = useNavigate();
+  const onClickPairing = (pairingId) => {
+    navigate(`/pairing/${pairingId}`);
+  };
+  return (
+    <ThemeProvider theme={theme}>
+      <h1>{title}</h1>
+      <PairingCurationWrapper>
+        <PhotoContainer>
+          <FirstPhotoContents
+            onClick={() => onClickPairing(pairingData[0].pairingId)}
+          >
+            <h1>{pairingData[0] && pairingData[0].title}</h1>
+          </FirstPhotoContents>
+          <SecondContainer>
+            <OtherPhotoContents
+              onClick={() => onClickPairing(pairingData[1].pairingId)}
+            >
+              <h1>{pairingData[1] && pairingData[1].title}</h1>
+            </OtherPhotoContents>
+            <OtherPhotoContents
+              onClick={() => onClickPairing(pairingData[2].pairingId)}
+            >
+              <h1>{pairingData[2] && pairingData[2].title}</h1>
+            </OtherPhotoContents>
+          </SecondContainer>
+        </PhotoContainer>
+        <ColumnContainer>
+          <LineContents
+            onClick={() => onClickPairing(pairingData[3].pairingId)}
+          >
+            <h1>{pairingData[3] && pairingData[3].title}</h1>
+          </LineContents>
+          <LineContents
+            onClick={() => onClickPairing(pairingData[4].pairingId)}
+          >
+            <h1>{pairingData[4] && pairingData[4].title}</h1>
+          </LineContents>
+          <LineContents
+            onClick={() => onClickPairing(pairingData[5].pairingId)}
+          >
+            <h1>{pairingData[5] && pairingData[5].title}</h1>
+          </LineContents>
+          <LineContents
+            onClick={() => onClickPairing(pairingData[6].pairingId)}
+          >
+            <h1>{pairingData[6] && pairingData[6].title}</h1>
+          </LineContents>
+          <LineContents
+            onClick={() => onClickPairing(pairingData[7].pairingId)}
+          >
+            <h1>{pairingData[7] && pairingData[7].title}</h1>
+          </LineContents>
+        </ColumnContainer>
+      </PairingCurationWrapper>
+    </ThemeProvider>
+  );
+};
+
+export default PairingCuration;

--- a/front/src/pages/PairingPage/PairingComponents/PairingTab.js
+++ b/front/src/pages/PairingPage/PairingComponents/PairingTab.js
@@ -1,0 +1,99 @@
+import styled, { ThemeProvider } from 'styled-components';
+import theme from '../../../styles/theme';
+import { Link } from 'react-router-dom';
+
+const TabBar = styled.ul`
+  margin: 10px;
+  font-weight: bold;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  list-style: none;
+  .selected {
+    color: ${({ theme }) => theme.colors.dark};
+  }
+`;
+
+const TabElement = styled.li`
+  color: ${({ theme }) => theme.colors.lightgray};
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 10px;
+  height: 34px;
+`;
+
+const StyledLink = styled(Link)`
+  text-decoration: none;
+  &:focus,
+  &:hover,
+  &:visited,
+  &:link,
+  &:active {
+    color: inherit;
+    text-decoration: none;
+  }
+`;
+
+const navObj = {
+  all: '/pairing',
+  film: '/pairing/film',
+  cuisine: '/pairing/cuisine',
+  music: '/pairing/music',
+  book: '/pairing/book',
+  etc: '/pairing/etc',
+};
+
+const PairingTab = ({ pathname = navObj.all }) => {
+  return (
+    <ThemeProvider theme={theme}>
+      <TabBar>
+        <StyledLink to={`${navObj.all}`}>
+          <TabElement
+            className={pathname === `${navObj.all}` ? 'selected' : ''}
+          >
+            전체
+          </TabElement>
+        </StyledLink>
+        <StyledLink to={`${navObj.film}`}>
+          <TabElement
+            className={pathname === `${navObj.film}` ? 'selected' : ''}
+          >
+            영화
+          </TabElement>
+        </StyledLink>
+        <StyledLink to={`${navObj.cuisine}`}>
+          <TabElement
+            className={pathname === `${navObj.cuisine}` ? 'selected' : ''}
+          >
+            음식 및 장소
+          </TabElement>
+        </StyledLink>
+        <StyledLink to={`${navObj.music}`}>
+          <TabElement
+            className={pathname === `${navObj.music}` ? 'selected' : ''}
+          >
+            음악
+          </TabElement>
+        </StyledLink>
+        <StyledLink to={`${navObj.book}`}>
+          <TabElement
+            className={pathname === `${navObj.book}` ? 'selected' : ''}
+          >
+            책
+          </TabElement>
+        </StyledLink>
+        <StyledLink to={`${navObj.etc}`}>
+          <TabElement
+            className={pathname === `${navObj.etc}` ? 'selected' : ''}
+          >
+            기타
+          </TabElement>
+        </StyledLink>
+      </TabBar>
+    </ThemeProvider>
+  );
+};
+
+export default PairingTab;

--- a/front/src/pages/PairingPage/PairingCuisine.js
+++ b/front/src/pages/PairingPage/PairingCuisine.js
@@ -1,0 +1,32 @@
+import PageContainer from '../../components/PageContainer';
+import PairingTab from './PairingComponents/PairingTab';
+import PairingCuration from './PairingComponents/PairingCuration';
+import { useSelector, useDispatch } from 'react-redux';
+import { useEffect } from 'react';
+import {
+  asyncGetCuisinePairingLike,
+  asyncGetCuisinePairingNewest,
+} from '../../store/modules/cuisinePairingSlice';
+const PairingCuisine = () => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(asyncGetCuisinePairingLike());
+    dispatch(asyncGetCuisinePairingNewest());
+  }, [dispatch]);
+
+  const pairingLikeData = useSelector((state) => state.cuisinePairing.likeData);
+  const pairingNewestData = useSelector(
+    (state) => state.cuisinePairing.newestData
+  );
+  const titleLike = '큐레이션 제목: Hot Pairing';
+  const titleNewest = '큐레이션 제목: New Pairing';
+  return (
+    <PageContainer footer>
+      <PairingTab pathname="/pairing/cuisine" />
+      <PairingCuration title={titleLike} pairingData={pairingLikeData} />
+      <PairingCuration title={titleNewest} pairingData={pairingNewestData} />
+    </PageContainer>
+  );
+};
+
+export default PairingCuisine;

--- a/front/src/pages/PairingPage/PairingDetail/PairingDetail.js
+++ b/front/src/pages/PairingPage/PairingDetail/PairingDetail.js
@@ -1,0 +1,95 @@
+import styled, { ThemeProvider } from 'styled-components';
+import theme from '../../../styles/theme';
+import PageContainer from '../../../components/PageContainer';
+import CollectionDetailHeader from '../../CollectionDetailPage/CollectionDetailHeader';
+import CollectionHeaderBtns from '../../CollectionDetailPage/CollectionHeaderBtns';
+import CollectionTags from '../../CollectionDetailPage/CollectionTags';
+import PairingOriginBook from './PairingOriginBook';
+
+import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { asyncGetOnePairing } from '../../../store/modules/pairingSlice';
+
+const TagBtn = styled.div`
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.lightgray};
+`;
+
+const OriginBookWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.lightgray};
+`;
+
+const MainBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.lightgray};
+`;
+
+const InfoTitle = styled.div`
+  margin: 10px 0px 0px 20px;
+  font-size: 20px;
+  color: ${({ theme }) => theme.colors.dark};
+  font-weight: 700;
+  padding-bottom: 10px;
+  display: flex;
+  flex-direction: row;
+  p {
+    color: ${({ theme }) => theme.colors.mainColor};
+  }
+`;
+const InfoContent = styled.div`
+  margin: 10px 0px 0px 20px;
+  font-size: 15px;
+  color: ${({ theme }) => theme.colors.darkgray};
+`;
+
+const PairingDetail = () => {
+  const dispatch = useDispatch();
+  const { pairingId } = useParams();
+  useEffect(() => {
+    dispatch(asyncGetOnePairing(pairingId));
+  }, [dispatch]);
+  const pairingData = useSelector((state) => state.pairing.data);
+  console.log(pairingData);
+  return (
+    <PageContainer footer>
+      <ThemeProvider theme={theme}>
+        <CollectionDetailHeader
+          title={pairingData.title}
+          writer={
+            pairingData.userInformation && pairingData.userInformation.nickName
+          }
+          update={new Date(pairingData.modifiedAt).toLocaleDateString()}
+        />
+        <TagBtn>
+          <CollectionTags taglist={['소설', '시간여행', '선택']} />
+          <CollectionHeaderBtns />
+        </TagBtn>
+        <OriginBookWrapper>
+          <InfoTitle>How about pairing this book</InfoTitle>
+          <PairingOriginBook
+            bookTitle="만약 엄청나게 긴 책제목이 있으먼 어쩌지? 이보다 긴 책제목이 사실 없을 것 간긴 한데 그래도 책제목에는 리밋이 있으면 안될텐데 말이야!!"
+            author="달리는 감자"
+            rating="4.9"
+            bookId="28"
+          ></PairingOriginBook>
+        </OriginBookWrapper>
+        <MainBody>
+          <InfoTitle>
+            With this&nbsp; <p>{pairingData.pairingCategory}</p>
+          </InfoTitle>
+          <InfoContent>
+            <p>{pairingData.body}</p>
+            <a href="/">{pairingData.outLinkPath}</a>
+          </InfoContent>
+        </MainBody>
+      </ThemeProvider>
+    </PageContainer>
+  );
+};
+
+export default PairingDetail;

--- a/front/src/pages/PairingPage/PairingDetail/PairingOriginBook.js
+++ b/front/src/pages/PairingPage/PairingDetail/PairingOriginBook.js
@@ -1,0 +1,77 @@
+import { useNavigate } from 'react-router-dom';
+import styled, { ThemeProvider } from 'styled-components';
+import theme from '../../../styles/theme';
+
+const BookWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: flex-end;
+  margin: 15px 0px;
+`;
+
+const PairingOriginBookContainer = styled.div`
+  @media screen and (max-width: 980px) {
+    padding: 0px 10px;
+  }
+  width: 25%;
+  padding: 0px 20px;
+  img {
+    width: 100%;
+    aspect-ratio: 7 / 10;
+    object-fit: cover;
+    &:hover {
+      box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
+    }
+  }
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+const BookInfo = styled.div`
+  display: flex;
+  max-width: 60%;
+  flex-direction: column;
+  font-size: 16px;
+  font-weight: 700;
+  justify-content: flex-start;
+  .title {
+    color: ${({ theme }) => theme.colors.dark};
+  }
+  .author {
+    font-weight: lighter;
+    color: ${({ theme }) => theme.colors.gray};
+  }
+  .rating {
+    color: ${({ theme }) => theme.colors.mainColor};
+  }
+`;
+
+const PairingOriginBook = ({ bookTitle, author, rating, bookId }) => {
+  const navigate = useNavigate();
+
+  const handleBookClick = () => {
+    navigate(`/book/${bookId}`);
+  };
+
+  return (
+    <ThemeProvider theme={theme}>
+      <BookWrapper>
+        <PairingOriginBookContainer onClick={handleBookClick}>
+          <img
+            src={process.env.PUBLIC_URL + '/images/books/bookcover_1.jpeg'}
+            alt="book cover"
+          />
+        </PairingOriginBookContainer>
+        <BookInfo>
+          <div className="title">{bookTitle}</div>
+          <div className="author">{author}</div>
+          <div className="rating">★ {rating}</div>
+        </BookInfo>
+      </BookWrapper>
+    </ThemeProvider>
+  );
+};
+
+export default PairingOriginBook;

--- a/front/src/pages/PairingPage/PairingEtc.js
+++ b/front/src/pages/PairingPage/PairingEtc.js
@@ -1,0 +1,30 @@
+import PageContainer from '../../components/PageContainer';
+import PairingTab from './PairingComponents/PairingTab';
+import PairingCuration from './PairingComponents/PairingCuration';
+import { useSelector, useDispatch } from 'react-redux';
+import { useEffect } from 'react';
+import {
+  asyncGetEtcPairingLike,
+  asyncGetEtcPairingNewest,
+} from '../../store/modules/etcPairingSlice';
+const PairingEtc = () => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(asyncGetEtcPairingLike());
+    dispatch(asyncGetEtcPairingNewest());
+  }, [dispatch]);
+
+  const pairingLikeData = useSelector((state) => state.etcPairing.likeData);
+  const pairingNewestData = useSelector((state) => state.etcPairing.newestData);
+  const titleLike = '큐레이션 제목: Hot Pairing';
+  const titleNewest = '큐레이션 제목: New Pairing';
+  return (
+    <PageContainer footer>
+      <PairingTab pathname="/pairing/etc" />
+      <PairingCuration title={titleLike} pairingData={pairingLikeData} />
+      <PairingCuration title={titleNewest} pairingData={pairingNewestData} />
+    </PageContainer>
+  );
+};
+
+export default PairingEtc;

--- a/front/src/pages/PairingPage/PairingFilm.js
+++ b/front/src/pages/PairingPage/PairingFilm.js
@@ -1,0 +1,32 @@
+import PageContainer from '../../components/PageContainer';
+import PairingTab from './PairingComponents/PairingTab';
+import PairingCuration from './PairingComponents/PairingCuration';
+import { useSelector, useDispatch } from 'react-redux';
+import { useEffect } from 'react';
+import {
+  asyncGetFilmPairingLike,
+  asyncGetFilmPairingNewest,
+} from '../../store/modules/filmPairingSlice';
+const PairingFilm = () => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(asyncGetFilmPairingLike());
+    dispatch(asyncGetFilmPairingNewest());
+  }, [dispatch]);
+
+  const pairingLikeData = useSelector((state) => state.filmPairing.likeData);
+  const pairingNewestData = useSelector(
+    (state) => state.filmPairing.newestData
+  );
+  const titleLike = '큐레이션 제목: Hot Pairing';
+  const titleNewest = '큐레이션 제목: New Pairing';
+  return (
+    <PageContainer footer>
+      <PairingTab pathname="/pairing/film" />
+      <PairingCuration title={titleLike} pairingData={pairingLikeData} />
+      <PairingCuration title={titleNewest} pairingData={pairingNewestData} />
+    </PageContainer>
+  );
+};
+
+export default PairingFilm;

--- a/front/src/pages/PairingPage/PairingMusic.js
+++ b/front/src/pages/PairingPage/PairingMusic.js
@@ -1,0 +1,32 @@
+import PageContainer from '../../components/PageContainer';
+import PairingTab from './PairingComponents/PairingTab';
+import PairingCuration from './PairingComponents/PairingCuration';
+import { useSelector, useDispatch } from 'react-redux';
+import { useEffect } from 'react';
+import {
+  asyncGetMusicPairingLike,
+  asyncGetMusicPairingNewest,
+} from '../../store/modules/musicPairingSlice';
+const PairingMusic = () => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(asyncGetMusicPairingLike());
+    dispatch(asyncGetMusicPairingNewest());
+  }, [dispatch]);
+
+  const pairingLikeData = useSelector((state) => state.musicPairing.likeData);
+  const pairingNewestData = useSelector(
+    (state) => state.musicPairing.newestData
+  );
+  const titleLike = '큐레이션 제목: Hot Pairing';
+  const titleNewest = '큐레이션 제목: New Pairing';
+  return (
+    <PageContainer footer>
+      <PairingTab pathname="/pairing/music" />
+      <PairingCuration title={titleLike} pairingData={pairingLikeData} />
+      <PairingCuration title={titleNewest} pairingData={pairingNewestData} />
+    </PageContainer>
+  );
+};
+
+export default PairingMusic;

--- a/front/src/pages/PairingPage/PairingWrite/PairingWrite.js
+++ b/front/src/pages/PairingPage/PairingWrite/PairingWrite.js
@@ -1,0 +1,15 @@
+import { ThemeProvider } from 'styled-components';
+import theme from '../../../styles/theme';
+import PageContainer from '../../../components/PageContainer';
+
+const PairingWrite = () => {
+  return (
+    <PageContainer footer>
+      <ThemeProvider theme={theme}>
+        <h1>페어링 작성</h1>
+      </ThemeProvider>
+    </PageContainer>
+  );
+};
+
+export default PairingWrite;

--- a/front/src/store/modules/allPairingSlice.js
+++ b/front/src/store/modules/allPairingSlice.js
@@ -1,0 +1,58 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from '../../api/axios';
+import {
+  PAIRING_ALL_LIKE_URL,
+  PAIRING_ALL_NEWEST_URL,
+} from '../../api/requests';
+
+const initialState = {
+  likeData: [],
+  newestData: [],
+  status: '',
+};
+
+export const asyncGetAllPairingLike = createAsyncThunk(
+  'pairingSlice/asyncGetAllPairingLike',
+  async () => {
+    return await axios
+      .get(PAIRING_ALL_LIKE_URL)
+      .then((res) => res.data.data.content);
+  }
+);
+
+export const asyncGetAllPairingNewest = createAsyncThunk(
+  'pairingSlice/asyncGetAllPairingNewest',
+  async () => {
+    return await axios
+      .get(PAIRING_ALL_NEWEST_URL)
+      .then((res) => res.data.data.content);
+  }
+);
+
+export const allPairingSlice = createSlice({
+  name: 'getPairing',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(asyncGetAllPairingLike.pending, (state) => {
+      state.status = 'pending';
+    });
+    builder.addCase(asyncGetAllPairingLike.fulfilled, (state, action) => {
+      state.likeData = action.payload;
+    });
+    builder.addCase(asyncGetAllPairingLike.rejected, (state) => {
+      state.status = 'rejected';
+    });
+    builder.addCase(asyncGetAllPairingNewest.pending, (state) => {
+      state.status = 'pending';
+    });
+    builder.addCase(asyncGetAllPairingNewest.fulfilled, (state, action) => {
+      state.newestData = action.payload;
+    });
+    builder.addCase(asyncGetAllPairingNewest.rejected, (state) => {
+      state.status = 'rejected';
+    });
+  },
+});
+
+export default allPairingSlice.reducer;

--- a/front/src/store/modules/bookPairingSlice.js
+++ b/front/src/store/modules/bookPairingSlice.js
@@ -1,0 +1,58 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from '../../api/axios';
+import {
+  PAIRING_BOOK_LIKE_URL,
+  PAIRING_BOOK_NEWEST_URL,
+} from '../../api/requests';
+
+const initialState = {
+  likeData: [],
+  newestData: [],
+  status: '',
+};
+
+export const asyncGetBookPairingLike = createAsyncThunk(
+  'pairingSlice/asyncGetBookPairingLike',
+  async () => {
+    return await axios
+      .get(PAIRING_BOOK_LIKE_URL)
+      .then((res) => res.data.data.content);
+  }
+);
+
+export const asyncGetBookPairingNewest = createAsyncThunk(
+  'pairingSlice/asyncGetBookPairingNewest',
+  async () => {
+    return await axios
+      .get(PAIRING_BOOK_NEWEST_URL)
+      .then((res) => res.data.data.content);
+  }
+);
+
+export const bookPairingSlice = createSlice({
+  name: 'getPairing',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(asyncGetBookPairingLike.pending, (state) => {
+      state.status = 'pending';
+    });
+    builder.addCase(asyncGetBookPairingLike.fulfilled, (state, action) => {
+      state.likeData = action.payload;
+    });
+    builder.addCase(asyncGetBookPairingLike.rejected, (state) => {
+      state.status = 'rejected';
+    });
+    builder.addCase(asyncGetBookPairingNewest.pending, (state) => {
+      state.status = 'pending';
+    });
+    builder.addCase(asyncGetBookPairingNewest.fulfilled, (state, action) => {
+      state.newestData = action.payload;
+    });
+    builder.addCase(asyncGetBookPairingNewest.rejected, (state) => {
+      state.status = 'rejected';
+    });
+  },
+});
+
+export default bookPairingSlice.reducer;

--- a/front/src/store/modules/cuisinePairingSlice.js
+++ b/front/src/store/modules/cuisinePairingSlice.js
@@ -1,0 +1,58 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from '../../api/axios';
+import {
+  PAIRING_CUISINE_LIKE_URL,
+  PAIRING_CUISINE_NEWEST_URL,
+} from '../../api/requests';
+
+const initialState = {
+  likeData: [],
+  newestData: [],
+  status: '',
+};
+
+export const asyncGetCuisinePairingLike = createAsyncThunk(
+  'pairingSlice/asyncGetCuisinePairingLike',
+  async () => {
+    return await axios
+      .get(PAIRING_CUISINE_LIKE_URL)
+      .then((res) => res.data.data.content);
+  }
+);
+
+export const asyncGetCuisinePairingNewest = createAsyncThunk(
+  'pairingSlice/asyncGetCuisinePairingNewest',
+  async () => {
+    return await axios
+      .get(PAIRING_CUISINE_NEWEST_URL)
+      .then((res) => res.data.data.content);
+  }
+);
+
+export const cuisinePairingSlice = createSlice({
+  name: 'getPairing',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(asyncGetCuisinePairingLike.pending, (state) => {
+      state.status = 'pending';
+    });
+    builder.addCase(asyncGetCuisinePairingLike.fulfilled, (state, action) => {
+      state.likeData = action.payload;
+    });
+    builder.addCase(asyncGetCuisinePairingLike.rejected, (state) => {
+      state.status = 'rejected';
+    });
+    builder.addCase(asyncGetCuisinePairingNewest.pending, (state) => {
+      state.status = 'pending';
+    });
+    builder.addCase(asyncGetCuisinePairingNewest.fulfilled, (state, action) => {
+      state.newestData = action.payload;
+    });
+    builder.addCase(asyncGetCuisinePairingNewest.rejected, (state) => {
+      state.status = 'rejected';
+    });
+  },
+});
+
+export default cuisinePairingSlice.reducer;

--- a/front/src/store/modules/etcPairingSlice.js
+++ b/front/src/store/modules/etcPairingSlice.js
@@ -1,0 +1,58 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from '../../api/axios';
+import {
+  PAIRING_ETC_LIKE_URL,
+  PAIRING_ETC_NEWEST_URL,
+} from '../../api/requests';
+
+const initialState = {
+  likeData: [],
+  newestData: [],
+  status: '',
+};
+
+export const asyncGetEtcPairingLike = createAsyncThunk(
+  'pairingSlice/asyncGetEtcPairingLike',
+  async () => {
+    return await axios
+      .get(PAIRING_ETC_LIKE_URL)
+      .then((res) => res.data.data.content);
+  }
+);
+
+export const asyncGetEtcPairingNewest = createAsyncThunk(
+  'pairingSlice/asyncGetEtcPairingNewest',
+  async () => {
+    return await axios
+      .get(PAIRING_ETC_NEWEST_URL)
+      .then((res) => res.data.data.content);
+  }
+);
+
+export const etcPairingSlice = createSlice({
+  name: 'getPairing',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(asyncGetEtcPairingLike.pending, (state) => {
+      state.status = 'pending';
+    });
+    builder.addCase(asyncGetEtcPairingLike.fulfilled, (state, action) => {
+      state.likeData = action.payload;
+    });
+    builder.addCase(asyncGetEtcPairingLike.rejected, (state) => {
+      state.status = 'rejected';
+    });
+    builder.addCase(asyncGetEtcPairingNewest.pending, (state) => {
+      state.status = 'pending';
+    });
+    builder.addCase(asyncGetEtcPairingNewest.fulfilled, (state, action) => {
+      state.newestData = action.payload;
+    });
+    builder.addCase(asyncGetEtcPairingNewest.rejected, (state) => {
+      state.status = 'rejected';
+    });
+  },
+});
+
+export default etcPairingSlice.reducer;

--- a/front/src/store/modules/filmPairingSlice.js
+++ b/front/src/store/modules/filmPairingSlice.js
@@ -1,0 +1,58 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from '../../api/axios';
+import {
+  PAIRING_FILM_LIKE_URL,
+  PAIRING_FILM_NEWEST_URL,
+} from '../../api/requests';
+
+const initialState = {
+  likeData: [],
+  newestData: [],
+  status: '',
+};
+
+export const asyncGetFilmPairingLike = createAsyncThunk(
+  'pairingSlice/asyncGetFilmPairingLike',
+  async () => {
+    return await axios
+      .get(PAIRING_FILM_LIKE_URL)
+      .then((res) => res.data.data.content);
+  }
+);
+
+export const asyncGetFilmPairingNewest = createAsyncThunk(
+  'pairingSlice/asyncGetFilmPairingNewest',
+  async () => {
+    return await axios
+      .get(PAIRING_FILM_NEWEST_URL)
+      .then((res) => res.data.data.content);
+  }
+);
+
+export const filmPairingSlice = createSlice({
+  name: 'getPairing',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(asyncGetFilmPairingLike.pending, (state) => {
+      state.status = 'pending';
+    });
+    builder.addCase(asyncGetFilmPairingLike.fulfilled, (state, action) => {
+      state.likeData = action.payload;
+    });
+    builder.addCase(asyncGetFilmPairingLike.rejected, (state) => {
+      state.status = 'rejected';
+    });
+    builder.addCase(asyncGetFilmPairingNewest.pending, (state) => {
+      state.status = 'pending';
+    });
+    builder.addCase(asyncGetFilmPairingNewest.fulfilled, (state, action) => {
+      state.newestData = action.payload;
+    });
+    builder.addCase(asyncGetFilmPairingNewest.rejected, (state) => {
+      state.status = 'rejected';
+    });
+  },
+});
+
+export default filmPairingSlice.reducer;

--- a/front/src/store/modules/musicPairingSlice.js
+++ b/front/src/store/modules/musicPairingSlice.js
@@ -1,0 +1,58 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from '../../api/axios';
+import {
+  PAIRING_MUSIC_LIKE_URL,
+  PAIRING_MUSIC_NEWEST_URL,
+} from '../../api/requests';
+
+const initialState = {
+  likeData: [],
+  newestData: [],
+  status: '',
+};
+
+export const asyncGetMusicPairingLike = createAsyncThunk(
+  'pairingSlice/asyncGetMusicPairingLike',
+  async () => {
+    return await axios
+      .get(PAIRING_MUSIC_LIKE_URL)
+      .then((res) => res.data.data.content);
+  }
+);
+
+export const asyncGetMusicPairingNewest = createAsyncThunk(
+  'pairingSlice/asyncGetMusicPairingNewest',
+  async () => {
+    return await axios
+      .get(PAIRING_MUSIC_NEWEST_URL)
+      .then((res) => res.data.data.content);
+  }
+);
+
+export const musicPairingSlice = createSlice({
+  name: 'getPairing',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(asyncGetMusicPairingLike.pending, (state) => {
+      state.status = 'pending';
+    });
+    builder.addCase(asyncGetMusicPairingLike.fulfilled, (state, action) => {
+      state.likeData = action.payload;
+    });
+    builder.addCase(asyncGetMusicPairingLike.rejected, (state) => {
+      state.status = 'rejected';
+    });
+    builder.addCase(asyncGetMusicPairingNewest.pending, (state) => {
+      state.status = 'pending';
+    });
+    builder.addCase(asyncGetMusicPairingNewest.fulfilled, (state, action) => {
+      state.newestData = action.payload;
+    });
+    builder.addCase(asyncGetMusicPairingNewest.rejected, (state) => {
+      state.status = 'rejected';
+    });
+  },
+});
+
+export default musicPairingSlice.reducer;

--- a/front/src/store/modules/pairingSlice.js
+++ b/front/src/store/modules/pairingSlice.js
@@ -1,0 +1,42 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from '../../api/axios';
+import { PAIRING_URL } from '../../api/requests';
+
+const initialState = {
+  data: [],
+  status: 'start',
+};
+
+export const asyncGetOnePairing = createAsyncThunk(
+  'pairingSlice/asyncGetOnePairing',
+  async (pairingId) => {
+    return await axios.get(`${PAIRING_URL}/${pairingId}`).then((res) => {
+      console.log(res.data.data.content);
+      return res.data.data;
+    });
+  }
+);
+
+export const pairingSlice = createSlice({
+  name: 'getPairing',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(asyncGetOnePairing.pending, (state) => {
+      //   console.log('pending', state, action);
+      state.status = 'pending';
+    });
+    builder.addCase(asyncGetOnePairing.fulfilled, (state, action) => {
+      //   console.log('fulfilled', state, action);
+      state.data = action.payload;
+      state.status = 'fulfilled';
+    });
+    builder.addCase(asyncGetOnePairing.rejected, (state) => {
+      //   console.log('reject', state, action);
+      state.data = [];
+      state.status = 'rejected';
+    });
+  },
+});
+
+export default pairingSlice.reducer;

--- a/front/src/store/store.js
+++ b/front/src/store/store.js
@@ -13,7 +13,13 @@ import storage from 'redux-persist/lib/storage';
 import counterReducer from './modules/counterSlice';
 import signUpReducer from './modules/signUpSlice';
 import signInReducer from './modules/signInSlice';
-
+import allPairingReducer from './modules/allPairingSlice';
+import pairingReducer from './modules/pairingSlice';
+import filmPairingReducer from './modules/filmPairingSlice';
+import cuisinePairingReducer from './modules/cuisinePairingSlice';
+import musicPairingReducer from './modules/musicPairingSlice';
+import bookPairingReducer from './modules/bookPairingSlice';
+import etcPairingReducer from './modules/etcPairingSlice';
 const persistConfig = {
   key: 'root',
   storage,
@@ -24,6 +30,13 @@ export const rootReducer = combineReducers({
   counter: counterReducer,
   signUp: signUpReducer,
   signIn: signInReducer,
+  allPairing: allPairingReducer,
+  filmPairing: filmPairingReducer,
+  cuisinePairing: cuisinePairingReducer,
+  musicPairing: musicPairingReducer,
+  bookPairing: bookPairingReducer,
+  etcPairing: etcPairingReducer,
+  pairing: pairingReducer,
 });
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);


### PR DESCRIPTION
![목록 및 상세 1차 구현](https://user-images.githubusercontent.com/107970881/202368894-1d140a2c-6a5f-4cc5-a1ef-e18e49269bd7.gif)

현재 페어링 목록 및 상세 조회는 일부 구현되었습니다!! 
(목록에서는 제목만 나오고, 상세에서는 제목, 글쓴이, 마지막 업데이트, body, outlink 등 조회 가능합니다!)

------------------
추가적으로 구현해야 할 것
1. 좋아요와 북마크 기능
2. 각 페어링 콘텐츠에 대한 코멘트
3. 이미지 띄우기 