### PR TITLE
[FE] feat: 리프레시 토큰 만료시간 연장, 페이지 접근 권한

### DIFF
--- a/front/src/api/authApi.js
+++ b/front/src/api/authApi.js
@@ -4,7 +4,7 @@ import { TOKEN_REFRESH_URL, SIGN_IN_URL, LOGOUT_URL } from './requests';
 
 // 만료 시간 (밀리초)
 const ACCESS_EXPIRY_TIME = 30 * 60 * 1000; // 30분
-const REFRESH_EXPIRY_TIME = 7 * 60 * 60 * 1000; // 7시간(420분)
+const REFRESH_EXPIRY_TIME = 24 * 60 * 60 * 1000; // 24시간
 
 const setAxiosHeaderAuth = (value) =>
   (axios.defaults.headers.common['Authorization'] = value);

--- a/front/src/components/PageContainer.js
+++ b/front/src/components/PageContainer.js
@@ -1,10 +1,34 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import CssBaseline from '@mui/material/CssBaseline';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Header from './Header';
 import Footer from './Footer';
+import { selectIsLogin } from '../store/modules/authSlice';
 
-const PageContainer = ({ children, header, footer }) => {
+const PageContainer = ({ children, header, footer, option = null }) => {
+  const isLoin = useSelector(selectIsLogin);
+  const navigate = useNavigate();
+  /**
+   * option
+   * null    =>  아무나 출입이 가능한 페이지
+   * true    =>  로그인한 유저만 출입이 가능한 페이지
+   * false   =>  로그인한 유저는 출입 불가능한 페이지
+   */
+
+  useEffect(() => {
+    if (option === null) return;
+    if (isLoin) {
+      // 로그인 한 상태
+      if (!option) navigate('/');
+    } else {
+      // 로그인 하지 않은 상태
+      if (option) navigate('/user/signin');
+    }
+  }, [navigate]);
+
   return (
     <Box
       sx={{

--- a/front/src/pages/SignInPage/SignInPage.js
+++ b/front/src/pages/SignInPage/SignInPage.js
@@ -73,7 +73,7 @@ const SignInPage = () => {
   };
 
   return (
-    <PageContainer footer>
+    <PageContainer footer option={false}>
       <ThemeProvider theme={theme}>
         <Container component="main" maxWidth="xs">
           <CssBaseline />

--- a/front/src/pages/SignUpPage/SignUpPage.js
+++ b/front/src/pages/SignUpPage/SignUpPage.js
@@ -63,7 +63,7 @@ const SignUpPage = () => {
   };
 
   return (
-    <PageContainer footer>
+    <PageContainer footer option={false}>
       <ThemeProvider theme={theme}>
         <Container component="main" maxWidth="xs">
           <CssBaseline />


### PR DESCRIPTION
# 리프레시 토큰 만료시간
7시간 -> 24시간

# 페이지 접근권한
PageContainer에 option prop을 추가하였습니다.
- null    =>  아무나 출입이 가능한 페이지
- true    =>  로그인한 유저만 출입이 가능한 페이지
- false   =>  로그인한 유저는 출입 불가능한 페이지

로그인 한 유저만 출입 가능한 페이지가 있다면 PageContainer에 option={true}를 설정해주세요