### PR TITLE
[BE] Fix: 맞춤 컬렉션 로직 변경

### DIFF
--- a/back/src/main/java/seb40_main_012/back/bookCollection/controller/BookCollectionController.java
+++ b/back/src/main/java/seb40_main_012/back/bookCollection/controller/BookCollectionController.java
@@ -58,13 +58,17 @@ public class BookCollectionController {
     @ResponseStatus(HttpStatus.OK)
     public BookCollectionDto.CollectionDetails getCollection(@PathVariable("collection-id") Long collectionId) {
         BookCollection collection = collectionService.getCollection(collectionId);
-        collection.setCollectionCover(
-                collection.getBookIsbn13().stream()
-                        .map(a -> bookService.findBook(a).getCover())
-                        .limit(4)
-                        .collect(Collectors.toList())
-        );
-        return BookCollectionDto.CollectionDetails.of(collection);
+        List<String> collectionCovers = collection.getBookIsbn13().stream()
+                .map(a -> bookService.findBook(a).getCover())
+                .limit(4)
+                .collect(Collectors.toList());
+//        collection.setCollectionCover(
+//                collection.getBookIsbn13().stream()
+//                        .map(a -> bookService.findBook(a).getCover())
+//                        .limit(4)
+//                        .collect(Collectors.toList())
+//        );
+        return BookCollectionDto.CollectionDetails.of(collection,collectionCovers);
     }
 
 

--- a/back/src/main/java/seb40_main_012/back/bookCollection/controller/BookCollectionController.java
+++ b/back/src/main/java/seb40_main_012/back/bookCollection/controller/BookCollectionController.java
@@ -135,10 +135,9 @@ public class BookCollectionController {
     @ResponseStatus(HttpStatus.OK)
 
     public ListResponseDto<BookCollectionDto.TagCollection> getCollectionByUserCategory() {
-
         List<BookCollection> collections = collectionService.findCollectionByUserCategory();
 
-        List<BookCollectionDto.TagCollection> tagCollectionDto = collections.stream().map(x -> BookCollectionDto.TagCollection.of(x)).collect(Collectors.toList());
+        List<BookCollectionDto.TagCollection> tagCollectionDto = collections.stream().map(x -> BookCollectionDto.TagCollection.of(x)).limit(4).collect(Collectors.toList());
         return new ListResponseDto<>(tagCollectionDto);
     }
 

--- a/back/src/main/java/seb40_main_012/back/bookCollection/dto/BookCollectionDto.java
+++ b/back/src/main/java/seb40_main_012/back/bookCollection/dto/BookCollectionDto.java
@@ -97,11 +97,11 @@ public class BookCollectionDto {
 
 
         //collection book
-        public static CollectionDetails of(BookCollection collection) {
+        public static CollectionDetails of(BookCollection collection,List<String> covers) {
             return CollectionDetails.builder()
                     .collectionId(collection.getCollectionId())
                     .title(collection.getTitle())
-                    .collectionCover(collection.getCollectionCover())
+                    .collectionCover(covers)
                     .content(collection.getContent())
                     .createdAt(collection.getCreatedAt())
                     .lastModifiedAt(collection.getLastModifiedAt())
@@ -145,6 +145,7 @@ public class BookCollectionDto {
         private String content;
         private String title;
         private Long collectionLike;
+        private boolean userLike;
         private List<BookDto.CollectionBook> books;
 
         public static BookCollectionDto.UserCollection of(BookCollection collection) {
@@ -153,6 +154,7 @@ public class BookCollectionDto {
                     .content(collection.getContent())
                     .title(collection.getTitle())
                     .collectionLike(collection.getCollectionLikes().stream().count())
+                    .userLike(collection.isUserLike())
                     .books(collection.getCollectionBooks().stream().map(x -> BookDto.CollectionBook.of(x.getBook())).collect(Collectors.toList()))
                     .build();
         }
@@ -168,6 +170,7 @@ public class BookCollectionDto {
         private String content;
         private String userName;
         private Long collectionLike;
+        private boolean userLike;
         private List<BookDto.CollectionBook> books;
 
         public static BookmarkedCollection of(BookCollection collection) {
@@ -177,6 +180,7 @@ public class BookCollectionDto {
                     .content(collection.getContent())
                     .userName(collection.getUser().getNickName())
                     .collectionLike(collection.getCollectionLikes().stream().count())
+                    .userLike(collection.isUserLike())
                     .books(collection.getCollectionBooks().stream().map(x -> BookDto.CollectionBook.of(x.getBook())).collect(Collectors.toList()))
                     .build();
         }

--- a/back/src/main/java/seb40_main_012/back/bookCollection/entity/BookCollection.java
+++ b/back/src/main/java/seb40_main_012/back/bookCollection/entity/BookCollection.java
@@ -33,6 +33,9 @@ public class BookCollection {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long collectionId;
     private String title;
+
+    @ElementCollection
+    private List<String> collectionCover = new ArrayList<>(); // 컬렉션에 속한 책 커버 4개. 컬렉션에 추가된 순으로 오름차순
     private String content;
     private Long likeCount;
     @Transient

--- a/back/src/main/java/seb40_main_012/back/bookCollection/entity/BookCollection.java
+++ b/back/src/main/java/seb40_main_012/back/bookCollection/entity/BookCollection.java
@@ -33,8 +33,6 @@ public class BookCollection {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long collectionId;
     private String title;
-    @ElementCollection
-    private List<String> collectionCover = new ArrayList<>(); // 컬렉션에 속한 책 커버 4개. 컬렉션에 추가된 순으로 오름차순
     private String content;
     private Long likeCount;
     @Transient

--- a/back/src/main/java/seb40_main_012/back/bookCollection/entity/BookCollectionLike.java
+++ b/back/src/main/java/seb40_main_012/back/bookCollection/entity/BookCollectionLike.java
@@ -14,11 +14,8 @@ public class BookCollectionLike {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "like_id")
-    private Long Id;
-    private String title;
-    private String content;
-    private String author;    //getUserName()
+    @Column
+    private Long likeId;
 
     @ManyToOne
     @JoinColumn(name = "collection_id")

--- a/back/src/main/java/seb40_main_012/back/bookCollection/repository/BookCollectionRepositorySupport.java
+++ b/back/src/main/java/seb40_main_012/back/bookCollection/repository/BookCollectionRepositorySupport.java
@@ -38,16 +38,30 @@ public class BookCollectionRepositorySupport extends QuerydslRepositorySupport {
         return collections;
     }
 
-    public List<BookCollection> findUserFitCollection(String genre){
+    //2. 해당 컬렉션 북의 컬렉션 아이디 조회
+    public List<BookCollection> findUserFitCollection(){
         List<BookCollection> collections =
                 queryFactory.select(bookCollection)
-                        .from(bookCollection,collectionBook)
-                        .leftJoin(bookCollection).on(collectionBook.book.genre.stringValue().eq(genre))
-                        .where()
-                        .orderBy()
+                        .from(bookCollection)
+                        .leftJoin(bookCollection.collectionBooks,collectionBook).fetchJoin()
+                        .where(
+                                bookCollection.collectionBooks.contains(collectionBook)
+                        )
+                        .orderBy(bookCollection.likeCount.desc())
+                        .orderBy(bookCollection.view.desc())
                         .fetch();
         return collections;
     }
+
+    //1. 장르 책 가진 컬렉션 북 조회
+    public List<BookCollectionBook> findCollectionBook(String genre){
+        List<BookCollectionBook> collections =
+                queryFactory.selectFrom(collectionBook)
+                        .where(collectionBook.book.genre.stringValue().eq(genre))
+                        .fetch();
+        return collections;
+    }
+
 
     private BooleanExpression genre(String genre){
         return null;

--- a/back/src/main/java/seb40_main_012/back/bookCollection/service/BookCollectionService.java
+++ b/back/src/main/java/seb40_main_012/back/bookCollection/service/BookCollectionService.java
@@ -1,6 +1,7 @@
 package seb40_main_012.back.bookCollection.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -30,12 +31,14 @@ import seb40_main_012.back.user.service.UserService;
 import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class BookCollectionService {
     private final UserService userService;
     private final BookService bookService;
@@ -244,15 +247,13 @@ public class BookCollectionService {
 
     public List<BookCollection> findCollectionByUserCategory() {
         User findUser = userService.getLoginUser();
-        String userCategory = findUser.getCategories().get(0).getCategory().getGenre().toString();
-        if(findUser.getCategories().isEmpty()){
-            userCategory = Genre.NOVEL.name();
-        }
-        Tag tag = tagRepository.findByTagName(userCategory).orElseThrow(() -> new BusinessLogicException(ExceptionCode.NOT_FOUND));
-        System.out.println("HERE>" + tag.getTagName());
+        List<Genre> genres = findUser.getCategories().stream().map(x -> x.getCategory().getGenre()).collect(Collectors.toList());
+        Collections.shuffle(genres);
+        String genre = genres.get(0).name();
+        log.info("this genre : " + genre);
 
-        List<BookCollectionTag> collectionTag = collectionTagRepository.findByTag(tag);
-        List<BookCollection> collections = collectionTag.stream().map(BookCollectionTag::getBookCollection).collect(Collectors.toList());
+        List<BookCollectionBook> collectionBooks = collectionRepositorySupport.findCollectionBook(genre);
+        List<BookCollection> collections = collectionBooks.stream().map(x -> x.getBookCollection()).collect(Collectors.toList());
         return collections;
     }
 


### PR DESCRIPTION
- asis : 유저 선호장르와 동일한 텍스트의 컬렉션 태그로 조회
- tobe : 유저 선호장르를 랜덤으로 선택하여 해당 장르의 책이 있는 컬렉션을 조회